### PR TITLE
fix: invoke installed Claude Code CLI directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Claude Code limits work with **fixed 5-hour windows**:
 
 ## Requirements
 
-- **Claude Code CLI** installed and logged in
+- **Claude Code CLI** installed, logged in, and available on your `PATH`
 - **Python 3.7+** with pip
 - **Node.js 18+** (for Claude Code)
 - **Linux/macOS/Windows** (optimized for Raspberry Pi)
@@ -72,7 +72,7 @@ claude login
 ### 2. Install Session Keeper
 ```bash
 # Clone this repository
-git clone https://github.com/awesomecoolraj/claude-session-keeper.git
+git clone https://github.com/nomadictuba2005/claude-session-keeper.git
 cd claude-session-keeper
 
 # Create virtual environment (recommended)
@@ -332,7 +332,7 @@ Contributions welcome! Please:
 
 ### Development Setup
 ```bash
-git clone https://github.com/awesomecoolraj/claude-session-keeper.git
+git clone https://github.com/nomadictuba2005/claude-session-keeper.git
 cd claude-session-keeper
 python3 -m venv dev-env
 source dev-env/bin/activate

--- a/claude_health_check_cli.py
+++ b/claude_health_check_cli.py
@@ -59,7 +59,7 @@ class ClaudeCodeHealthCheck:
         """Run a simple Claude Code CLI command"""
         try:
             # Use Claude Code CLI to send a simple message
-            self.logger.info("Executing: npx claude --dangerously-skip-permissions Hi")
+            self.logger.info("Executing: claude --dangerously-skip-permissions Hi")
             
             # RAM optimizations for Pi 3B
             import os
@@ -75,7 +75,7 @@ class ClaudeCodeHealthCheck:
             self.logger.info(f"RAM optimization: Node.js limited to 256MB")
             
             process = subprocess.Popen(
-                'npx claude --dangerously-skip-permissions Hi',
+                'claude --dangerously-skip-permissions Hi',
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- invoke the installed `claude` binary directly instead of `npx claude`
- document that Claude Code must be available on `PATH`
- fix README clone commands to point at this repository

## Problem
On environments where Claude Code is already installed as the `claude` binary, `npx claude --dangerously-skip-permissions Hi` can fail with:

```text
npm error could not determine executable to run
```

Calling `claude --dangerously-skip-permissions Hi` succeeds on the same machine, so this change switches the health check to use the installed CLI directly.

## Verification
- `uv run claude_health_check_cli.py --once`